### PR TITLE
Correctly show 1st of the month when its on sunday

### DIFF
--- a/src/md-date-range-picker.js
+++ b/src/md-date-range-picker.js
@@ -328,7 +328,7 @@
             var dates = [],
                 monthStartDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1),
                 monthEndDate = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 0),
-                calendarStartDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1 - (monthStartDate.getDay() - getFirstDayOfWeek())),
+                calendarStartDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1 - (monthStartDate.getDay()==0?6:(monthStartDate.getDay() - getFirstDayOfWeek()))),
                 calendarEndDate = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 7 - (monthEndDate.getDay() - getFirstDayOfWeek())),
                 calendar = calendarStartDate;
             while (calendar < calendarEndDate) {


### PR DESCRIPTION
Fixes issue: #17 

When the first day of the week is set to Monday and the first day of the month is on a Sunday set the calendar start date 6 days before the first of  the month to prevent the cut off of the first day of the month.