### PR TITLE
fix a bug caused by the dateStart and dateEnd were an object

### DIFF
--- a/dist/md-date-range-picker.js
+++ b/dist/md-date-range-picker.js
@@ -481,17 +481,18 @@
             var d = new Date(), d1 = new Date(d.getFullYear(), d.getMonth(), d.getDate());
 
             $scope.dateStart = d1;
-            $scope.dateEnd = d1;
+            $scope.dateEnd = d;
             $scope.selectedTemplate = 'TD';
             $scope.selectedTemplateName = $scope.selectedDateText();
             //$scope.focusToDate(d);
         }
 
         function handleClickSelectYesterday() {
-            var d = new Date(), d1 = new Date(d.getFullYear(), d.getMonth(), d.getDate() - 1);
+            var d = new Date(), d1 = new Date(d.getFullYear(), d.getMonth(), d.getDate() - 1), 
+            d2 = new Date(d.getFullYear(), d.getMonth(), d.getDate() - 1);
 
             $scope.dateStart = d1;
-            $scope.dateEnd = d1;
+            $scope.dateEnd = d2;
             $scope.selectedTemplate = 'YD';
             $scope.selectedTemplateName = $scope.selectedDateText();
             //$scope.focusToDate(d);

--- a/src/md-date-range-picker.js
+++ b/src/md-date-range-picker.js
@@ -482,17 +482,18 @@
             var d = new Date(), d1 = new Date(d.getFullYear(), d.getMonth(), d.getDate());
 
             $scope.dateStart = d1;
-            $scope.dateEnd = d1;
+            $scope.dateEnd = d;
             $scope.selectedTemplate = 'TD';
             $scope.selectedTemplateName = $scope.selectedDateText();
             //$scope.focusToDate(d);
         }
 
         function handleClickSelectYesterday() {
-            var d = new Date(), d1 = new Date(d.getFullYear(), d.getMonth(), d.getDate() - 1);
+            var d = new Date(), d1 = new Date(d.getFullYear(), d.getMonth(), d.getDate() - 1), 
+            d2 = new Date(d.getFullYear(), d.getMonth(), d.getDate() - 1);
 
             $scope.dateStart = d1;
-            $scope.dateEnd = d1;
+            $scope.dateEnd = d2;
             $scope.selectedTemplate = 'YD';
             $scope.selectedTemplateName = $scope.selectedDateText();
             //$scope.focusToDate(d);


### PR DESCRIPTION
Otherwise, the dateStart will end in 23:59:59 (at line 744 ).
```
$scope.model.dateStart && $scope.model.dateStart.setHours(0, 0, 0, 0);
$scope.model.dateEnd && $scope.model.dateEnd.setHours(23, 59, 59, 999);
```